### PR TITLE
Fixed path handling

### DIFF
--- a/RCT2Browser/BrowserForm.cs
+++ b/RCT2Browser/BrowserForm.cs
@@ -322,9 +322,10 @@ namespace RCTDataEditor {
 		}
 		/** <summary> Called to load the settings file. </summary> */
 		private void LoadSettings(object sender, EventArgs e) {
-			if (File.Exists(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + "\\Settings.xml")) {
+			string pathToSettings = Path.Combine(Path.GetDirectoryName (Assembly.GetEntryAssembly ().Location),"Settings.xml");
+			if (File.Exists(pathToSettings)) {
 				XmlDocument doc = new XmlDocument();
-				doc.Load(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + "\\Settings.xml");
+				doc.Load(pathToSettings);
 				XmlNodeList element;
 
 				element = doc.GetElementsByTagName("DefaultDirectory");
@@ -364,7 +365,7 @@ namespace RCTDataEditor {
 			settings.AppendChild(element);
 			element.AppendChild(doc.CreateTextNode(Attraction.QuickLoad.ToString()));
 
-			doc.Save(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + "\\Settings.xml");
+			doc.Save(Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),"Settings.xml"));
 		}
 		/** <summary> Called when the browse default button is pressed. </summary> */
 		private void BrowseDefaultDirectory(object sender, EventArgs e) {

--- a/RCT2Browser/BrowserForm.cs
+++ b/RCT2Browser/BrowserForm.cs
@@ -392,7 +392,7 @@ namespace RCTDataEditor {
 						if (info.Source == SourceTypes.Custom) item.ImageIndex = 2;
 						else if (info.Source == SourceTypes.RCT2) item.ImageIndex = 0;
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, info.Source.ToString()));
-						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, files[i].Substring(files[i].LastIndexOf('\\') + 1)));
+						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, Path.GetFileName(files[i])));
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, info.Name));
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, info.Type.ToString()));
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, info.Subtype.ToString()));
@@ -403,7 +403,7 @@ namespace RCTDataEditor {
 						if (info.Source == SourceTypes.Custom) item.ImageIndex = 2;
 						else if (info.Source == SourceTypes.RCT2) item.ImageIndex = 0;
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, info.Source.ToString()));
-						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, files[i].Substring(files[i].LastIndexOf('\\') + 1)));
+						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, Path.GetFileName(files[i])));
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, info.Name));
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, info.Type.ToString()));
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, info.Subtype.ToString()));
@@ -432,7 +432,7 @@ namespace RCTDataEditor {
 						if (info.Source == SourceTypes.Custom) item.ImageIndex = 2;
 						else if (info.Source == SourceTypes.RCT2) item.ImageIndex = 0;
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, ""));
-						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, files[i].Substring(files[i].LastIndexOf('\\') + 1)));
+						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, Path.GetFileName(files[i])));
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, ""));
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, ""));
 						item.SubItems.Add(new ListViewItem.ListViewSubItem(item, ""));
@@ -617,7 +617,7 @@ namespace RCTDataEditor {
 			if (e.Item.Selected && ((sender as ListView).SelectedItems.Count == 0 || (sender as ListView).SelectedItems[0] == e.Item)) {
 				currentList = name;
 				objectIndex = e.ItemIndex;
-				objectData = ObjectData.ReadObject(directory + "/" + e.Item.SubItems[2].Text);
+				objectData = ObjectData.ReadObject(Path.Combine(directory,e.Item.SubItems[2].Text));
 				this.frame = 0;
 				this.UpdateImages(); this.UpdateInfo(); this.UpdateColorRemap();
 				this.labelCurrentObject.Text = (objectData != null ? objectData.ObjectHeader.FileName + ".DAT" : "");

--- a/RCT2Browser/DataObjects/ObjectData.cs
+++ b/RCT2Browser/DataObjects/ObjectData.cs
@@ -279,8 +279,7 @@ public class ObjectData {
 		ObjectDataInfo objInfo = new ObjectDataInfo();
 
 		try {
-			objInfo.FileName = path.Substring(path.Replace('/', '\\').LastIndexOf('\\') + 1);
-			objInfo.FileName = objInfo.FileName.Substring(0, objInfo.FileName.Length - 4);
+				objInfo.FileName = Path.GetFileNameWithoutExtension(path);
 			BinaryReader reader = new BinaryReader(new FileStream(path, FileMode.Open, FileAccess.Read), Encoding.Unicode);
 
 			// Read the object data header
@@ -326,13 +325,13 @@ public class ObjectData {
 	}
 	/** <summary> Reads and returns object data from a path. </summary> */
 	public static ObjectData ReadObject(string path) {
+
 		ObjectData obj = null;
 		ObjectDataHeader objectHeader = new ObjectDataHeader();
 		ChunkHeader chunkHeader = new ChunkHeader();
 
 		try {
-			objectHeader.FileName = path.Substring(path.Replace('/', '\\').LastIndexOf('\\') + 1);
-			objectHeader.FileName = objectHeader.FileName.Substring(0, objectHeader.FileName.Length - 4);
+			objectHeader.FileName = Path.GetFileNameWithoutExtension(path);
 			BinaryReader reader = new BinaryReader(new FileStream(path, FileMode.Open, FileAccess.Read), Encoding.Unicode);
 
 			objectHeader.Read(reader);


### PR DESCRIPTION
I've replaced instances of manipulation of paths with string operations with methods from System.Path. This is a more reliable method of handling paths than string operations; it's cross platform and it doesn't rely on assumptions about the format of the path.
