### PR TITLE
Add nuspec for ObjectData

### DIFF
--- a/ObjectData/ObjectData.csproj
+++ b/ObjectData/ObjectData.csproj
@@ -29,6 +29,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ObjectData/ObjectData.nuspec
+++ b/ObjectData/ObjectData.nuspec
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>RCT2Tools.ObjectData</id>
+    <version>$version$</version>
+    <title>RCT2Tools.ObjectData</title>
+    <authors>Robert Jordan</authors>
+    <owners>Ted John</owners>
+    <projectUrl>https://github.com/trigger-death/RCT2Tools</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Library for reading and writing RCT2 data files.</description>
+    <copyright>Copyright Robert Jordan 2015</copyright>
+    <tags>RollerCoaster Tycoon RCT2</tags>
+  </metadata>
+</package>


### PR DESCRIPTION
I would like to put the nuspec upstream so I don't have to keep rebasing it on top of changes to this repository.

This is for the NuGet package which I am currently maintaining:
https://www.nuget.org/packages/RCT2Tools.ObjectData